### PR TITLE
fix: specify --no-tests for np release

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/terrestris/eslint-config-typescript"
   },
   "scripts": {
-    "release": "np --no-yarn"
+    "release": "np --no-yarn --no-tests"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": ">= ~6",


### PR DESCRIPTION
Sorry about the noise, just trying to release a new version and `np` doesn't let me.

This one adds the `--no-tests` parameter to the release command, since we don't have any tests here.

@terrestris/devs Please review.